### PR TITLE
adds automatic execution of build task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,32 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+    {
+      "label": "webpack",
+      "type": "shell",
+      "command": "npx",
+      "args": ["webpack", "--watch"],
+      "isBackground": true,
+      "runOptions": {
+          "runOn": "folderOpen"  // This makes it run automatically
+        },
+      "problemMatcher": {
+        "owner": "external",
+        "pattern": {
+          "regexp": "^(.*): \\s*Error: (.*)$",
+          "file": 1,
+          "message": 2
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "webpack is watching the files…",
+          "endsPattern": ".*Compiled successfully.*"
+        }
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
If you accept this PR, the `webpack build` task will start triggering automatically when you open the project in VS Code.

It will run in its own terminal and look something like this:

<img width="618" alt="Screenshot 2023-10-08 at 7 19 48 AM" src="https://github.com/TeddyFrye/battleship/assets/10442975/a04f2634-45d8-404f-b9e1-9795ecc37962">

As can be seen in the above screenshot, it reports errors in the terminal -- not quite as nice as making a big red error symbol appear, but better than nothing.